### PR TITLE
319 - timeout hangs

### DIFF
--- a/channels_redis/pubsub.py
+++ b/channels_redis/pubsub.py
@@ -401,7 +401,7 @@ class RedisSingleShardConnection:
                                     data
                                 )
             else:
-                logger.warn("_do_receiving does not have subscribed receiver")
+                logger.warning("_do_receiving does not have subscribed receiver")
                 await asyncio.sleep(1)
 
     def _notify_consumers(self, mtype):
@@ -456,10 +456,8 @@ class RedisSingleShardConnection:
         connection check will be beneficial in the same way as it is for a low-traffic site.
         """
         while True:
-            await asyncio.sleep(1)
+            await asyncio.sleep(3)
             try:
                 await self._get_sub_conn()
-            except asyncio.CancelledError:
-                raise
             except Exception:
                 logger.exception("Unexpected exception in keepalive task:")

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -204,3 +204,10 @@ async def test_proxied_methods_coroutine_check(channel_layer):
     # below Python 3.8.
     if sys.version_info >= (3, 8):
         assert inspect.iscoroutinefunction(channel_layer.send)
+
+
+@pytest.mark.asyncio
+async def test_receive_hang(channel_layer):
+    channel_name = await channel_layer.new_channel(prefix="test-channel")
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(channel_layer.receive(channel_name), timeout=1)

--- a/tests/test_pubsub_sentinel.py
+++ b/tests/test_pubsub_sentinel.py
@@ -161,3 +161,10 @@ def test_multi_event_loop_garbage_collection(channel_layer):
     assert len(channel_layer._layers.values()) == 0
     async_to_sync(test_send_receive)(channel_layer)
     assert len(channel_layer._layers.values()) == 0
+
+
+@pytest.mark.asyncio
+async def test_receive_hang(channel_layer):
+    channel_name = await channel_layer.new_channel(prefix="test-channel")
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(channel_layer.receive(channel_name), timeout=1)


### PR DESCRIPTION
Could `_do_keepalive()` be coming along once we've done all or part of our cleanup and then reconnecting everything. This would in theory put us back into a position where no message will ever come and we won't timeout.